### PR TITLE
Add additional debug information on the exception problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,18 @@ new ExceptionApiProblem(new \Exception('message', 500));
   "detail": "message",
   "exception": {
     "message": "message",
+    "type": "RuntimeException",
     "code": 500,
+    "line": 23,
+    "file": "exception.php",
     "trace": "#0 [internal function]: ...",
     "previous": [
       {
         "message": "previous",
+        "type": "InvalidArgumentException",
         "code": 0,
+        "line": 20,
+        "file": "exception.php",
         "trace": "#0 [internal function]: ..."
       }
     ]

--- a/spec/Http/ExceptionApiProblemSpec.php
+++ b/spec/Http/ExceptionApiProblemSpec.php
@@ -65,8 +65,11 @@ class ExceptionApiProblemSpec extends ObjectBehavior
             'title' => HttpApiProblem::getTitleForStatusCode(500),
             'detail' => 'message',
             'exception' => [
+                'type' => Exception::class,
                 'message' => 'message',
                 'code' => 500,
+                'line' => $exception->getLine(),
+                'file' => $exception->getFile(),
                 'trace' => $exception->getTraceAsString(),
                 'previous' => [],
             ],
@@ -86,22 +89,44 @@ class ExceptionApiProblemSpec extends ObjectBehavior
             'title' => HttpApiProblem::getTitleForStatusCode(500),
             'detail' => 'message',
             'exception' => [
+                'type' => Exception::class,
                 'message' => 'message',
                 'code' => 0,
+                'line' => $exception->getLine(),
+                'file' => $exception->getFile(),
                 'trace' => $exception->getTraceAsString(),
                 'previous' => [
                     [
+                        'type' => Exception::class,
                         'message' => 'previous',
                         'code' => 2,
+                        'line' => $previous->getLine(),
+                        'file' => $previous->getFile(),
                         'trace' => $previous->getTraceAsString(),
                     ],
                     [
+                        'type' => Exception::class,
                         'message' => 'first',
                         'code' => 1,
+                        'line' => $first->getLine(),
+                        'file' => $first->getFile(),
                         'trace' => $first->getTraceAsString(),
                     ],
                 ],
             ],
+        ]);
+    }
+
+    public function it_uses_the_class_of_the_exception_when_no_message_exists(): void
+    {
+        $exception = new Exception();
+        $this->beConstructedWith($exception);
+
+        $this->toArray()->shouldBe([
+            'status' => 500,
+            'type' => HttpApiProblem::TYPE_HTTP_RFC,
+            'title' => HttpApiProblem::getTitleForStatusCode(500),
+            'detail' => Exception::class,
         ]);
     }
 }

--- a/src/Http/ExceptionApiProblem.php
+++ b/src/Http/ExceptionApiProblem.php
@@ -23,7 +23,7 @@ class ExceptionApiProblem extends HttpApiProblem implements DebuggableApiProblem
             : 500;
 
         parent::__construct($statusCode, [
-            'detail' => $exception->getMessage(),
+            'detail' => $exception->getMessage() ?: \get_class($exception),
         ]);
     }
 
@@ -51,8 +51,11 @@ class ExceptionApiProblem extends HttpApiProblem implements DebuggableApiProblem
     private function serializeException(Throwable $throwable): array
     {
         return [
+            'type' => \get_class($throwable),
             'message' => $throwable->getMessage(),
             'code' => $throwable->getCode(),
+            'line' => $throwable->getLine(),
+            'file' => $throwable->getFile(),
             'trace' => $throwable->getTraceAsString(),
         ];
     }


### PR DESCRIPTION
Some exceptions don't contain a message, which results in en empty details section.
This PR adds additional debug information and the type of the exception as a message.