### PR TITLE
explode trace on newline, so trace is returned in an array & is more readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,12 @@ new ExceptionApiProblem(new \Exception('message', 500));
     "code": 500,
     "line": 23,
     "file": "exception.php",
-    "trace": "#0 [internal function]: ...",
+    "trace": [
+         "#0 [internal function]: ...",
+         "#1 [internal function]: ...",
+         "#3 [internal function]: ...",
+         "..."
+    ],
     "previous": [
       {
         "message": "previous",
@@ -71,7 +76,12 @@ new ExceptionApiProblem(new \Exception('message', 500));
         "code": 0,
         "line": 20,
         "file": "exception.php",
-        "trace": "#0 [internal function]: ..."
+        "trace": [
+            "#0 [internal function]: ...",
+            "#1 [internal function]: ...",
+            "#3 [internal function]: ...",
+            "..."
+        ]
       }
     ]
   }

--- a/spec/Http/ExceptionApiProblemSpec.php
+++ b/spec/Http/ExceptionApiProblemSpec.php
@@ -70,7 +70,7 @@ class ExceptionApiProblemSpec extends ObjectBehavior
                 'code' => 500,
                 'line' => $exception->getLine(),
                 'file' => $exception->getFile(),
-                'trace' => $exception->getTraceAsString(),
+                'trace' => explode("\n", $exception->getTraceAsString()),
                 'previous' => [],
             ],
         ]);
@@ -94,7 +94,7 @@ class ExceptionApiProblemSpec extends ObjectBehavior
                 'code' => 0,
                 'line' => $exception->getLine(),
                 'file' => $exception->getFile(),
-                'trace' => $exception->getTraceAsString(),
+                'trace' => explode("\n", $exception->getTraceAsString()),
                 'previous' => [
                     [
                         'type' => Exception::class,
@@ -102,7 +102,7 @@ class ExceptionApiProblemSpec extends ObjectBehavior
                         'code' => 2,
                         'line' => $previous->getLine(),
                         'file' => $previous->getFile(),
-                        'trace' => $previous->getTraceAsString(),
+                        'trace' => explode("\n", $previous->getTraceAsString()),
                     ],
                     [
                         'type' => Exception::class,
@@ -110,7 +110,7 @@ class ExceptionApiProblemSpec extends ObjectBehavior
                         'code' => 1,
                         'line' => $first->getLine(),
                         'file' => $first->getFile(),
-                        'trace' => $first->getTraceAsString(),
+                        'trace' => explode("\n", $first->getTraceAsString()),
                     ],
                 ],
             ],

--- a/src/Http/ExceptionApiProblem.php
+++ b/src/Http/ExceptionApiProblem.php
@@ -56,7 +56,7 @@ class ExceptionApiProblem extends HttpApiProblem implements DebuggableApiProblem
             'code' => $throwable->getCode(),
             'line' => $throwable->getLine(),
             'file' => $throwable->getFile(),
-            'trace' => $throwable->getTraceAsString(),
+            'trace' => explode("\n", $throwable->getTraceAsString()),
         ];
     }
 }


### PR DESCRIPTION
explode trace on newline, so trace is returned in an array & is more readable