### PR TITLE
Do not reveal exception message automatically

### DIFF
--- a/src/Http/ExceptionApiProblem.php
+++ b/src/Http/ExceptionApiProblem.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phpro\ApiProblem\Http;
 
 use Phpro\ApiProblem\DebuggableApiProblemInterface;
+use Phpro\ApiProblem\PublicExceptionInterface;
 use Throwable;
 
 class ExceptionApiProblem extends HttpApiProblem implements DebuggableApiProblemInterface
@@ -22,8 +23,13 @@ class ExceptionApiProblem extends HttpApiProblem implements DebuggableApiProblem
             ? $exceptionCode
             : 500;
 
+        $detail = 'Internal error';
+        if ($exception instanceof PublicExceptionInterface) {
+            $detail = $exception->getMessage() ?: \get_class($exception);
+        }
+
         parent::__construct($statusCode, [
-            'detail' => $exception->getMessage() ?: \get_class($exception),
+            'detail' => $detail,
         ]);
     }
 

--- a/src/PublicExceptionInterface.php
+++ b/src/PublicExceptionInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\ApiProblem;
+
+interface PublicExceptionInterface extends \Throwable
+{
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | https://github.com/phpro/api-problem-bundle/issues/13

#### Summary

Do not reveal exception message automatically as it could be considered as a security breach.
