### PR TITLE
Return 500 for non numeric exception codes

### DIFF
--- a/spec/Http/ExceptionApiProblemSpec.php
+++ b/spec/Http/ExceptionApiProblemSpec.php
@@ -129,4 +129,19 @@ class ExceptionApiProblemSpec extends ObjectBehavior
             'detail' => Exception::class,
         ]);
     }
+
+    public function it_should_deal_with_string_exception_codes(): void
+    {
+        $exception = new class($message = 'hell no') extends Exception {
+            protected $code = 'nope';
+        };
+        $this->beConstructedWith($exception);
+
+        $this->toArray()->shouldBe([
+            'status' => 500,
+            'type' => HttpApiProblem::TYPE_HTTP_RFC,
+            'title' => HttpApiProblem::getTitleForStatusCode(500),
+            'detail' => $message,
+        ]);
+    }
 }

--- a/src/Http/ExceptionApiProblem.php
+++ b/src/Http/ExceptionApiProblem.php
@@ -18,7 +18,7 @@ class ExceptionApiProblem extends HttpApiProblem implements DebuggableApiProblem
     {
         $this->exception = $exception;
         $exceptionCode = $exception->getCode();
-        $statusCode = $exceptionCode >= 400 && $exceptionCode <= 599
+        $statusCode = is_int($exception) && $exceptionCode >= 400 && $exceptionCode <= 599
             ? $exceptionCode
             : 500;
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #14

#### Summary

```
>>> $exceptionCode = "42S02"
=> "42S02"
>>> $statusCode = $exceptionCode >= 400 && $exceptionCode <= 599 ? $exceptionCode : 500
=> "42S02"
```

Expected behaviour

An exception passed to Phpro\ApiProblem\Http\ExceptionApiProblem that returns a non-numeric getStatus() (and they do exist) should result in a code of 500, and not throw another exception complaining about the non-numeric status code that it tries to use to pass to the parent constructor (class Phpro\ApiProblem\Http\HttpApiProblem).
