### PR TITLE
(fix): exception will never be a int

### DIFF
--- a/spec/Http/ExceptionApiProblemSpec.php
+++ b/spec/Http/ExceptionApiProblemSpec.php
@@ -144,4 +144,17 @@ class ExceptionApiProblemSpec extends ObjectBehavior
             'detail' => $message,
         ]);
     }
+
+    public function it_should_use_code_as_status_code_when_valid_http_status_code_error(): void
+    {
+        $message = 'an honest error';
+        $this->beConstructedWith(new \InvalidArgumentException($message, 400));
+
+        $this->toArray()->shouldBe([
+            'status' => 400,
+            'type' => HttpApiProblem::TYPE_HTTP_RFC,
+            'title' => HttpApiProblem::getTitleForStatusCode(400),
+            'detail' => $message,
+        ]);
+    }
 }

--- a/src/Http/ExceptionApiProblem.php
+++ b/src/Http/ExceptionApiProblem.php
@@ -18,7 +18,7 @@ class ExceptionApiProblem extends HttpApiProblem implements DebuggableApiProblem
     {
         $this->exception = $exception;
         $exceptionCode = $exception->getCode();
-        $statusCode = is_int($exception) && $exceptionCode >= 400 && $exceptionCode <= 599
+        $statusCode = is_int($exceptionCode) && $exceptionCode >= 400 && $exceptionCode <= 599
             ? $exceptionCode
             : 500;
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary of your change. -->

Status and Status Code will never be other than 500, because the code is trying to assert that a `\Throwable` is a `int`
